### PR TITLE
Implement Cloth Config & Mod Menu API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ classes/
 
 # fabric
 
+fabric/bin/
+common/bin
 run/
 logs/
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,17 @@ configure(subprojects) {
     apply plugin: "architectury-plugin"
     apply plugin: "dev.architectury.loom"
 
+    repositories {
+        maven { url "https://maven.shedaniel.me/" }
+        maven { url "https://maven.terraformersmc.com/releases/" }
+    }
+
     dependencies {
         minecraft "com.mojang:minecraft:${project.minecraft_version}"
         mappings loom.officialMojangMappings()
+        modApi("me.shedaniel.cloth:cloth-config-fabric:13.0.121") {
+            exclude(group: "net.fabricmc.fabric-api")
+        }
+        modApi "com.terraformersmc:modmenu:9.0.0"
     }
 }

--- a/common/src/main/java/net/pcal/splitscreen/Mod.java
+++ b/common/src/main/java/net/pcal/splitscreen/Mod.java
@@ -56,6 +56,8 @@ public interface Mod {
 
     WindowDescription onResolutionChange(MinecraftWindowContext res);
 
+    void onUpdateConfig();
+
     void onInitialize(Path configDirectory);
 
     void onStopping();

--- a/common/src/main/java/net/pcal/splitscreen/WindowModeImpl.java
+++ b/common/src/main/java/net/pcal/splitscreen/WindowModeImpl.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import net.pcal.splitscreen.config.ConfigHandler;
+
 import static net.pcal.splitscreen.WindowMode.WindowStyle.FULLSCREEN;
 import static net.pcal.splitscreen.WindowMode.WindowStyle.SPLITSCREEN;
 import static net.pcal.splitscreen.WindowMode.WindowStyle.WINDOWED;
@@ -36,7 +38,7 @@ import static net.pcal.splitscreen.WindowMode.WindowStyle.WINDOWED;
  * @author pcal
  * @since 0.0.1
  */
-record WindowModeImpl(
+public record WindowModeImpl(
         String name,
         WindowStyle style,
         Function<MinecraftWindowContext, Integer> xFn,
@@ -54,24 +56,27 @@ record WindowModeImpl(
         return new WindowDescription(style, xFn.apply(res), yFn.apply(res), widthFn.apply(res), heightFn.apply(res));
     }
 
-    static List<WindowMode> getModes() {
+    public static List<WindowMode> getModes() {
+        return getModes(ConfigHandler.get().screenGap);
+    }
+
+    public static List<WindowMode> getModes(int gap) {
         final List<WindowMode> modes = new ArrayList<>();
-        final int gap = 2; // TODO make this configurable
         addMode(modes, "WINDOWED", WINDOWED, r -> r.windowRect().x(), r -> r.windowRect().y(),
                 r -> r.windowRect().width(), r -> r.windowRect().height());
-        addMode(modes, "LEFT", SPLITSCREEN, r -> 0, r -> 0, r -> r.screenWidth() / 2 - gap, r -> r.screenHeight());
-        addMode(modes, "RIGHT", SPLITSCREEN, r -> r.screenWidth() / 2 + gap, r -> 0, r -> r.screenWidth() / 2 - gap, r -> r.screenHeight());
-        addMode(modes, "TOP", SPLITSCREEN, r -> 0, r -> 0, r -> r.screenWidth(), r -> r.screenHeight() / 2 - gap);
-        addMode(modes, "BOTTOM", SPLITSCREEN, r -> 0, r -> r.screenHeight() / 2 + gap, r -> r.screenWidth(), r -> r.screenHeight() / 2 - gap);
-        addMode(modes, "TOP_LEFT", SPLITSCREEN, r -> 0, r -> 0,
+                addMode(modes, "LEFT", SPLITSCREEN, r -> 0, r -> 0, r -> r.screenWidth() / 2 - gap, r -> r.screenHeight());
+                addMode(modes, "RIGHT", SPLITSCREEN, r -> r.screenWidth() / 2 + gap, r -> 0, r -> r.screenWidth() / 2 - gap, r -> r.screenHeight());
+                addMode(modes, "TOP", SPLITSCREEN, r -> 0, r -> 0, r -> r.screenWidth(), r -> r.screenHeight() / 2 - gap);
+                addMode(modes, "BOTTOM", SPLITSCREEN, r -> 0, r -> r.screenHeight() / 2 + gap, r -> r.screenWidth(), r -> r.screenHeight() / 2 - gap);
+                addMode(modes, "TOP_LEFT", SPLITSCREEN, r -> 0, r -> 0,
                 r -> r.screenWidth() / 2 - gap, r -> r.screenHeight() / 2 - gap);
-        addMode(modes, "TOP_RIGHT", SPLITSCREEN, r -> r.screenWidth() / 2 + gap, r -> 0,
+                addMode(modes, "TOP_RIGHT", SPLITSCREEN, r -> r.screenWidth() / 2 + gap, r -> 0,
                 r -> r.screenWidth() / 2 - gap, r -> r.screenHeight() / 2 - gap);
-        addMode(modes, "BOTTOM_LEFT", SPLITSCREEN, r -> 0, r -> r.screenHeight() / 2 + gap,
+                addMode(modes, "BOTTOM_LEFT", SPLITSCREEN, r -> 0, r -> r.screenHeight() / 2 + gap,
                 r -> r.screenWidth() / 2 - gap, r -> r.screenHeight() / 2 - gap);
-        addMode(modes, "BOTTOM_RIGHT", SPLITSCREEN, r -> r.screenWidth() / 2 + gap, r -> r.screenHeight() / 2 + gap,
+                addMode(modes, "BOTTOM_RIGHT", SPLITSCREEN, r -> r.screenWidth() / 2 + gap, r -> r.screenHeight() / 2 + gap,
                 r -> r.screenWidth() / 2 - gap, r -> r.screenHeight() / 2 - gap);
-        addMode(modes, "FULLSCREEN", FULLSCREEN, no(), no(), no(), no());
+                addMode(modes, "FULLSCREEN", FULLSCREEN, no(), no(), no(), no());
         return modes;
     }
 

--- a/common/src/main/java/net/pcal/splitscreen/config/ConfigHandler.java
+++ b/common/src/main/java/net/pcal/splitscreen/config/ConfigHandler.java
@@ -1,0 +1,49 @@
+package net.pcal.splitscreen.config;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import net.pcal.splitscreen.Mod;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+
+public class ConfigHandler {
+    private static final Logger logger = LoggerFactory.getLogger("config");
+    private static final File file = new File(net.fabricmc.loader.api.FabricLoader.getInstance().getConfigDir().toFile(), "splitscreen.json");
+    private static ConfigHandler INSTANCE = new ConfigHandler();
+
+    public int screenGap = 0;
+    public String mode = "TOP";
+
+    public static void save() {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        file.getParentFile().mkdirs();
+
+        try (FileWriter writer = new FileWriter(file)) {
+            gson.toJson(INSTANCE, writer);
+        } catch (IOException e) {
+            logger.error("Splitscreen mod couldn't save config", e);
+        }
+
+        Mod.mod().onUpdateConfig();
+    }
+
+    public static void load() {
+        Gson gson = new Gson();
+        if (!file.exists()) return;
+        try (Reader reader = new FileReader(file)) {
+            INSTANCE = gson.fromJson(reader, ConfigHandler.class);
+        } catch (Exception e) {
+            logger.error("Splitscreen mod couldn't load config, deleting it...", e);
+            file.delete();
+        }
+    }
+
+    public static ConfigHandler get() {
+        return INSTANCE;
+    }
+
+}

--- a/common/src/main/java/net/pcal/splitscreen/config/ConfigScreen.java
+++ b/common/src/main/java/net/pcal/splitscreen/config/ConfigScreen.java
@@ -1,0 +1,53 @@
+package net.pcal.splitscreen.config;
+
+import me.shedaniel.clothconfig2.api.ConfigBuilder;
+import me.shedaniel.clothconfig2.api.ConfigCategory;
+import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
+import me.shedaniel.clothconfig2.impl.builders.DropdownMenuBuilder.CellCreatorBuilder;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.pcal.splitscreen.WindowModeImpl;
+
+public class ConfigScreen {
+
+    private static final ConfigHandler config = ConfigHandler.get();
+
+    public static Screen getConfigScreenByCloth(Screen parent) {
+        ConfigBuilder builder = ConfigBuilder.create()
+                .setParentScreen(parent)
+                .setTitle(Component.translatable("splitscreen.config.title"));
+
+        ConfigEntryBuilder eb = builder.entryBuilder();
+
+        ConfigCategory settings = builder.getOrCreateCategory(Component.translatable("config.settings"));
+
+        settings.addEntry(
+                eb.startDropdownMenu(
+                        Component.translatable("splitscreen.config.window_mode.label"),
+                        config.mode,
+                        mode -> mode.toString(),
+                        CellCreatorBuilder.of(mode -> Component
+                                .translatable("splitscreen.config.modes." + mode.toString().toLowerCase())))
+                        .setDefaultValue("WINDOWED")
+                        .setSelections(WindowModeImpl.getModes().stream().map((mode) -> mode.getName()).toList())
+                        .setSuggestionMode(false)
+                        .setSaveConsumer(modeName -> {
+                            config.mode = modeName;
+                        })
+                        .build());
+
+        settings.addEntry(
+                eb.startIntField(
+                        Component.translatable("splitscreen.config.gap.label"),
+                        config.screenGap)
+                        .setDefaultValue(0)
+                        .setSaveConsumer(val -> config.screenGap = val)
+                        .build());
+
+        builder.setSavingRunnable(ConfigHandler::save);
+
+        return builder.build();
+
+    }
+
+}

--- a/common/src/main/java/net/pcal/splitscreen/config/ModMenuIntegration.java
+++ b/common/src/main/java/net/pcal/splitscreen/config/ModMenuIntegration.java
@@ -1,0 +1,13 @@
+package net.pcal.splitscreen.config;
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+
+public class ModMenuIntegration implements ModMenuApi {
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return parent -> {
+            return ConfigScreen.getConfigScreenByCloth(parent);
+        };
+    }
+}

--- a/fabric/src/main/resources/assets/splitscreen/lang/en_us.json
+++ b/fabric/src/main/resources/assets/splitscreen/lang/en_us.json
@@ -1,0 +1,16 @@
+{
+    "splitscreen.config.title": "Splitscreen Mod",
+    "splitscreen.config.settings" : "Settings",
+    "splitscreen.config.gap.label" : "Window Gap",
+    "splitscreen.config.window_mode.label": "Window Window Position",
+    "splitscreen.config.modes.windowed": "Windowed",
+    "splitscreen.config.modes.left": "Left",
+    "splitscreen.config.modes.right": "Right",
+    "splitscreen.config.modes.top": "Top",
+    "splitscreen.config.modes.bottom": "Bottom",
+    "splitscreen.config.modes.top_left": "Top Left",
+    "splitscreen.config.modes.top_right": "Top Right",
+    "splitscreen.config.modes.bottom_left": "Bottom Left",
+    "splitscreen.config.modes.bottom_right": "Bottom Right",
+    "splitscreen.config.modes.fullscreen": "Fullscreen"
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -16,6 +16,9 @@
   "entrypoints": {
     "client": [
       "net.pcal.splitscreen.mod.fabric.FabricClientInitializer"
+    ],
+    "modmenu": [
+      "net.pcal.splitscreen.config.ModMenuIntegration"
     ]
   },
   "mixins": [


### PR DESCRIPTION
<img src="https://github.com/pcal43/splitscreen/assets/15958874/1b6f8c98-5326-4a17-8970-9caef86fca7e" alt="drawing" width="400"/>

## Why?
- I wanted to make the gap size configurable.
- I wanted to be able to change the location of the windows with a controller.
- Configuration is a good thing to have moving forward.

## How
By adding a ConfigHandler, we can change properties from the config.json and sync these properties in the local object. From here we call `Mod.mod().onUpdateConfig()` to change the necessary values.

### Side Note
In order to update the window properly while out of scope of `WindowMixin` I implemented a reflect Method that changes the accessibility and invokes the method `Window.setMode()' in order to update the window position on a config change.

Slightly messy but it works.