### PR TITLE
Fix #18: Support for multiple monitors

### DIFF
--- a/src/main/java/net/pcal/splitscreen/ModImpl.java
+++ b/src/main/java/net/pcal/splitscreen/ModImpl.java
@@ -107,7 +107,7 @@ class ModImpl implements Mod {
             this.savedWindowRect = mcContext.windowRect();
         }
         currentModeIndex = (currentModeIndex + 1) % modes.size();
-        final MinecraftWindowContext ctx = new MinecraftWindowContext(mcContext.screenWidth(), mcContext.screenHeight(), this.savedWindowRect);
+        final MinecraftWindowContext ctx = new MinecraftWindowContext(mcContext.screenWidth(), mcContext.screenHeight(), this.savedWindowRect, mcContext.monitorX(), mcContext.monitorY());
         return this.modes.get(currentModeIndex).getFor(ctx);
     }
 

--- a/src/main/java/net/pcal/splitscreen/WindowMode.java
+++ b/src/main/java/net/pcal/splitscreen/WindowMode.java
@@ -53,7 +53,7 @@ public interface WindowMode {
     /**
      * Lets Minecraft describe to us the current window and its context.
      */
-    record MinecraftWindowContext(int screenWidth, int screenHeight, Rectangle windowRect) {
+    record MinecraftWindowContext(int screenWidth, int screenHeight, Rectangle windowRect, int monitorX, int monitorY) {
     }
 
 

--- a/src/main/java/net/pcal/splitscreen/WindowModeImpl.java
+++ b/src/main/java/net/pcal/splitscreen/WindowModeImpl.java
@@ -58,17 +58,17 @@ record WindowModeImpl(
         final List<WindowMode> modes = new ArrayList<>();
         addMode(modes, "WINDOWED", WINDOWED, r -> r.windowRect().x(), r -> r.windowRect().y(),
                 r -> r.windowRect().width(), r -> r.windowRect().height());
-        addMode(modes, "LEFT", SPLITSCREEN, r -> 0, r -> 0, r -> r.screenWidth() / 2 - gap, r -> r.screenHeight());
-        addMode(modes, "RIGHT", SPLITSCREEN, r -> r.screenWidth() / 2 + gap, r -> 0, r -> r.screenWidth() / 2 - gap, r -> r.screenHeight());
-        addMode(modes, "TOP", SPLITSCREEN, r -> 0, r -> 0, r -> r.screenWidth(), r -> r.screenHeight() / 2 - gap);
-        addMode(modes, "BOTTOM", SPLITSCREEN, r -> 0, r -> r.screenHeight() / 2 + gap, r -> r.screenWidth(), r -> r.screenHeight() / 2 - gap);
-        addMode(modes, "TOP_LEFT", SPLITSCREEN, r -> 0, r -> 0,
+        addMode(modes, "LEFT", SPLITSCREEN, r -> r.monitorX(), r -> r.monitorY(), r -> r.screenWidth() / 2 - gap, r -> r.screenHeight());
+        addMode(modes, "RIGHT", SPLITSCREEN, r -> r.monitorX() + r.screenWidth() / 2 + gap, r -> r.monitorY(), r -> r.screenWidth() / 2 - gap, r -> r.screenHeight());
+        addMode(modes, "TOP", SPLITSCREEN, r -> r.monitorX(), r -> r.monitorY(), r -> r.screenWidth(), r -> r.screenHeight() / 2 - gap);
+        addMode(modes, "BOTTOM", SPLITSCREEN, r -> r.monitorX(), r -> r.monitorY() + r.screenHeight() / 2 + gap, r -> r.screenWidth(), r -> r.screenHeight() / 2 - gap);
+        addMode(modes, "TOP_LEFT", SPLITSCREEN, r -> r.monitorX(), r -> r.monitorY(),
                 r -> r.screenWidth() / 2 - gap, r -> r.screenHeight() / 2 - gap);
-        addMode(modes, "TOP_RIGHT", SPLITSCREEN, r -> r.screenWidth() / 2 + gap, r -> 0,
+        addMode(modes, "TOP_RIGHT", SPLITSCREEN, r -> r.monitorX() + r.screenWidth() / 2 + gap, r -> r.monitorY(),
                 r -> r.screenWidth() / 2 - gap, r -> r.screenHeight() / 2 - gap);
-        addMode(modes, "BOTTOM_LEFT", SPLITSCREEN, r -> 0, r -> r.screenHeight() / 2 + gap,
+        addMode(modes, "BOTTOM_LEFT", SPLITSCREEN, r -> r.monitorX(), r -> r.monitorY() + r.screenHeight() / 2 + gap,
                 r -> r.screenWidth() / 2 - gap, r -> r.screenHeight() / 2 - gap);
-        addMode(modes, "BOTTOM_RIGHT", SPLITSCREEN, r -> r.screenWidth() / 2 + gap, r -> r.screenHeight() / 2 + gap,
+        addMode(modes, "BOTTOM_RIGHT", SPLITSCREEN, r -> r.monitorX() + r.screenWidth() / 2 + gap, r -> r.monitorY() + r.screenHeight() / 2 + gap,
                 r -> r.screenWidth() / 2 - gap, r -> r.screenHeight() / 2 - gap);
         addMode(modes, "FULLSCREEN", FULLSCREEN, no(), no(), no(), no());
         return modes;

--- a/src/main/java/net/pcal/splitscreen/mod/fabric/mixins/WindowMixin.java
+++ b/src/main/java/net/pcal/splitscreen/mod/fabric/mixins/WindowMixin.java
@@ -84,7 +84,6 @@ public abstract class WindowMixin {
     @Shadow
     private Optional<VideoMode> preferredFullscreenVideoMode;
 
-
     @Shadow
     public abstract boolean isFullscreen();
 
@@ -103,7 +102,7 @@ public abstract class WindowMixin {
         // ok so the issue seems to be that this triggers a framebuffersizechanged when it normally wouldn't
         // minecraftclient is listening for it on resolutionChanged and it isn't ready.  so we probably just need to find
         // a later time to move the window.
-        //splitscreen_repositionWindow(mod().onWindowCreate(splitscreen_getWindowContext()));
+        // splitscreen_repositionWindow(mod().onWindowCreate(splitscreen_getWindowContext()));
     }
 
     @Inject(method = "toggleFullScreen()V", at = @At("HEAD"), cancellable = true)
@@ -143,9 +142,9 @@ public abstract class WindowMixin {
             syslog().warn("could not determine monitor");
             return null;
         }
-        final VideoMode videoMode = findBestMonitor().getPreferredVidMode(this.preferredFullscreenVideoMode);
+        final VideoMode videoMode = monitor.getPreferredVidMode(this.preferredFullscreenVideoMode);
         final Rectangle currentWindow = new Rectangle(x, y, width, height);
-        return new MinecraftWindowContext(videoMode.getWidth(), videoMode.getHeight(), currentWindow);
+        return new MinecraftWindowContext(videoMode.getWidth(), videoMode.getHeight(), currentWindow, monitor.getX(), monitor.getY());
     }
 
     @Unique


### PR DESCRIPTION
## Summary
I fixed the mod to work on non-primary monitors.

## Changes
I added monitor position tracking by passing the monitor's X and Y coordinates through the context. Now all splitscreen positioning calculations account for the monitor's offset in screen space, so windows are positioned correctly on whichever monitor you're using.

## Testing
Tested on a multi-monitor setup and confirmed splitscreen modes now work properly on secondary monitors.